### PR TITLE
Fix: Prevent crash during network diagnostics on non-Supervisor installs

### DIFF
--- a/custom_components/icloud3/apple_acct/internet_error.py
+++ b/custom_components/icloud3/apple_acct/internet_error.py
@@ -391,6 +391,8 @@ class InternetConnection_ErrorHandler:
                 'address': ['fe80::802:b59f:10ee:face/64'], 'nameservers': [], 'gateway': None,
                 'ready': False}, 'wifi': None, 'vlan': None}
         '''
+        if "hassio_network_info" not in Gb.hass.data:
+            return None 
         interfaces = Gb.hass.data['hassio_network_info']['interfaces']
         for interface in interfaces:
             if interface['ipv6']['method'] != 'disabled':


### PR DESCRIPTION
This PR prevents a login failure exception by adding a check for the existence of `hassio_network_info` in the `ha_system_network_ipv6_info` function.

Specifically, when I try to log into an Apple account on the Chinese server that requires a verification code, the process fails with an "Unknown Error". The `icloud3.log` shows that after receiving a 302 response from the server, the integration incorrectly assumes a network error has occurred.

**icloud3.log:**

```text
10-11 16:28:40 [pyicloud_ic3:0315]  zho**1**in@, Initialize PyiCloud Service, Set up iCloud Location Services connection
10-11 16:28:40 [apple_acct_u:0238]  zho**1**in@, Validate Username/Password
...
10-11 16:28:43 [pyicloud_ses:0291] 
⠀⠀⠀🔻 ZHO**1**IN@, POST, RESPONSE, _AUTHENTICATE_WITH_TOKEN/589 ▼
⠀⠀⠀❗ items={'code': 302, 'ok': True}
10-11 16:28:43 [pyicloud_ic3:0475]  zho**1**in@, Password, login_successful=False
10-11 16:28:43 [pyicloud_ic3:0531]  zho**1**in@, Authentication Failed, Apple Server Location-`usa`, Apple Server not Available (Connection Refused or Other Error), ErrorCode-302
```

This triggers a traceback in the `home-assistant.log`:

```text
2025-10-11 16:23:12.214 ERROR (SyncWorker_7) [custom_components.icloud3]  zho**0**in@, Authentication Failed, Apple Server Location-`usa`, Apple Server not Available (Connection Refused or Other Error), ErrorCode-302
2025-10-11 16:23:12.257 ERROR (MainThread) [aiohttp.server] Error handling request from 127.0.0.1
Traceback (most recent call last):
...
  File "/config/custom_components/icloud3/config_flow.py", line 2351, in async_step_update_apple_acct
    ipv6_info = Gb.InternetError.ha_system_network_ipv6_info()
  File "/config/custom_components/icloud3/apple_acct/internet_error.py", line 394, in ha_system_network_ipv6_info
    interfaces = Gb.hass.data['hassio_network_info']['interfaces']
                 ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'hassio_network_info'
```

Based on my analysis (with some help from Gemini), my understanding of the issue is as follows:

1.  The login process receives a `302` response, which should signify that a 2FA verification code is required.
2.  However, `icloud3` interprets the `302` as a network problem and initiates a network diagnostic routine.
3.  This routine attempts to fetch IPv6 network information via the Home Assistant Supervisor.
4.  My HA instance is installed via Docker and does not have a Supervisor, so the `hassio_network_info` key does not exist in `hass.data`.
5.  This results in a `KeyError`, which crashes the diagnostic process and prematurely terminates the entire login flow before I can be prompted for the verification code.

My proposed fix is to add a preliminary check to ensure `hassio_network_info` exists before attempting to access it. This prevents the crash.

I acknowledge that a more robust solution might involve modifying the login logic to correctly handle the `302` response as a 2FA request. However, I am not familiar enough with the codebase to implement that. This PR addresses the immediate crash and allows the login process to continue.